### PR TITLE
add @MinLen annotation to getUpperBounds()

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/WildcardType.java
+++ b/src/java.base/share/classes/java/lang/reflect/WildcardType.java
@@ -24,6 +24,7 @@
  */
 
 package java.lang.reflect;
+import org.checkerframework.checker.index.MinLen;
 
 /**
  * WildcardType represents a wildcard type expression, such as
@@ -53,7 +54,7 @@ public interface WildcardType extends Type {
      *     bounds refer to a parameterized type that cannot be instantiated
      *     for any reason
      */
-    Type[] getUpperBounds();
+    Type @MinLen(1) [] getUpperBounds();
 
     /**
      * Returns an array of {@code Type} objects representing the

--- a/src/java.base/share/classes/java/lang/reflect/WildcardType.java
+++ b/src/java.base/share/classes/java/lang/reflect/WildcardType.java
@@ -24,7 +24,7 @@
  */
 
 package java.lang.reflect;
-import org.checkerframework.checker.index.MinLen;
+import org.checkerframework.checker.value.MinLen;
 
 /**
  * WildcardType represents a wildcard type expression, such as

--- a/src/java.base/share/classes/java/lang/reflect/WildcardType.java
+++ b/src/java.base/share/classes/java/lang/reflect/WildcardType.java
@@ -24,7 +24,7 @@
  */
 
 package java.lang.reflect;
-import org.checkerframework.checker.value.MinLen;
+import org.checkerframework.common.value.MinLen;
 
 /**
  * WildcardType represents a wildcard type expression, such as


### PR DESCRIPTION
According to the documentation 'Returns an array of {@code Type} objects representing the  upper bound(s) of this type variable.  If no upper bound is explicitly declared, the upper bound is {@code Object}.'. Therefore, getUpperBounds() function returns an array of atleast length 1.